### PR TITLE
Fix: instance de et sous classe de

### DIFF
--- a/reconciliation/config.sh
+++ b/reconciliation/config.sh
@@ -16,8 +16,8 @@ echo "
       \"max_edits_per_minute\": 1,
       \"tag\": \"openrefine-\${version}\",
       \"properties\": {
-        \"instance_of\": \"P1\",
-        \"subclass_of\": \"P2\"
+        \"instance_of\": \"P47\",
+        \"subclass_of\": \"P53\"
       },
       \"constraints\": {
         \"property_constraint_pid\": \"P2302\",


### PR DESCRIPTION
Suite au chargement des nouvelles classes et propriétés pour la mise en prod l'ordre des propriétés a changé (les id aussi du coup).

Cette PR corrige les identifiants des propriétés `instance de` et `sous classe de` dans la configuration du réconciliateur.

⚠️ Il faudra mettre à jour le manifest dans refmovies !